### PR TITLE
Maturin build fail in master.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,10 @@ name = "pravega_client"
 crate-type = ["cdylib"]
 
 [features]
-default = ["python_binding"]
+default = ["python_binding", "extension-module"]
 javascript_binding = ["wasm-bindgen"]
 python_binding = ["pyo3", "pyo3-asyncio"]
+extension-module = ["pyo3/extension-module"]
 
 #Run tests for bindings using command cargo test --no-default-features
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,9 @@ name = "pravega_client"
 crate-type = ["cdylib"]
 
 [features]
-default = ["python_binding", "extension-module"]
+default = ["python_binding"]
 javascript_binding = ["wasm-bindgen"]
 python_binding = ["pyo3", "pyo3-asyncio"]
-extension-module = ["pyo3/extension-module"]
 
 #Run tests for bindings using command cargo test --no-default-features
 


### PR DESCRIPTION
**Change log description**  
In github action we see below error
```
maturin failed
  Caused by: Error ensuring manylinux_2_35 compliance
  Caused by: Your library links libpython (libpython3.7m.so.1.0), which libraries must not do. Have you forgotten to activate the extension-module feature?
Traceback (most recent call last):
  File ".github/workflows/build_wheel.py", line 24, in <module>
    subprocess.run(command, check=True)
  File "/opt/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/subprocess.py", line 512, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['maturin', 'build', '--release', '--compatibility=manylinux_2_35', '--interpreter
```

**Purpose of the change**  
Closes #26 

**What the code does**  
Add external module

**How to verify it**  
(Optional: steps to verify that the changes are effective)
